### PR TITLE
Add storybook as separate package

### DIFF
--- a/packages/storybook/.storybook/config.js
+++ b/packages/storybook/.storybook/config.js
@@ -1,0 +1,5 @@
+import { configure } from '@storybook/react'
+
+const req = require.context('../src', true, /.stories.(ts|js)x?$/)
+
+configure(req, module)

--- a/packages/storybook/.storybook/presets.js
+++ b/packages/storybook/.storybook/presets.js
@@ -1,0 +1,1 @@
+module.exports = ['@storybook/preset-typescript']

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@kodiak/storybook",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0",
+    "react-scripts": "3.3.0"
+  },
+  "scripts": {
+    "storybook": "start-storybook -p 9009",
+    "build-storybook": "build-storybook"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.2.2",
+    "@storybook/addon-actions": "^5.3.6",
+    "@storybook/addon-links": "^5.3.6",
+    "@storybook/addons": "^5.3.6",
+    "@storybook/preset-typescript": "^1.2.0",
+    "@storybook/react": "^5.3.6",
+    "fork-ts-checker-webpack-plugin": "^4.0.1",
+    "react-docgen-typescript-loader": "^3.6.0",
+    "ts-loader": "^6.2.1"
+  }
+}

--- a/packages/storybook/src/Components/Box.stories.tsx
+++ b/packages/storybook/src/Components/Box.stories.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react'
+
+export default {
+  title: 'Box',
+}
+
+export const initial = function() {
+  return <div>Test</div>
+}

--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es5"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.test.*"]
+}


### PR DESCRIPTION
This adds Storybook to Kodiak as a separate package. Keeping it as a separate package will allow us to treat it as a yarn/lerna workspace and import the appropriate modules from sibling packages to create stories.