### PR TITLE
Add the Flex component and variant support

### DIFF
--- a/packages/box/src/Box.tsx
+++ b/packages/box/src/Box.tsx
@@ -23,6 +23,7 @@ import {
   PositionProps,
   shadow,
   ShadowProps,
+  get,
 } from 'styled-system'
 
 /**
@@ -49,11 +50,20 @@ const shouldForwardProp = createShouldForwardProp([
  *
  * @param props any
  */
-const sx = (props: any): SerializedStyles => {
+function sx(props: any): SerializedStyles {
   return css(props.sx)(props.theme)
 }
 
-type BoxProps = { as?: React.ElementType } & SpaceProps &
+function variant(props: any) {
+  const { variant, theme } = props
+  const variantKey = variant && variant.split('.')[1]
+  return css(get(theme, variant, get(theme, variantKey)))(theme)
+}
+
+type BoxProps = {
+  as?: React.ElementType
+  variant?: string
+} & SpaceProps &
   ColorProps &
   TypographyProps &
   LayoutProps &
@@ -77,6 +87,7 @@ export const Box = styled<'div', BoxProps>('div', {
     margin: 0,
     minWidth: 0,
   },
+  variant,
   space,
   color,
   typography,

--- a/packages/box/src/Box.tsx
+++ b/packages/box/src/Box.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { css, IntrinsicSxElements } from 'theme-ui'
+import { css, IntrinsicSxElements, Theme } from 'theme-ui'
 import { SerializedStyles } from '@emotion/serialize'
 import { createShouldForwardProp } from '@styled-system/should-forward-prop'
 import {
@@ -54,10 +54,39 @@ function sx(props: any): SerializedStyles {
   return css(props.sx)(props.theme)
 }
 
-function variant(props: any) {
-  const { variant, theme } = props
+/**
+ * variant
+ *
+ * Returns a function that accept's the components
+ * props. The variant and theme props are passed into `css`
+ * to generate the Emotion css that will be applied to the
+ * component
+ *
+ * Variants are defined in the theme with a key and then variant.
+ *
+ * {
+ *   buttons: {
+ *     primary: {
+ *       bg: 'primary',
+ *       color: 'white',
+ *     }
+ *   }
+ * }
+ */
+interface VariantProps {
+  theme: Theme
+  variant?: string
+}
+
+function variant({ variant, theme }: VariantProps) {
   const variantKey = variant && variant.split('.')[1]
-  return css(get(theme, variant, get(theme, variantKey)))(theme)
+  return css(
+    get(
+      theme,
+      variant as string | number,
+      get(theme, variantKey as string | number),
+    ),
+  )(theme)
 }
 
 type BoxProps = {

--- a/packages/box/src/Box.tsx
+++ b/packages/box/src/Box.tsx
@@ -73,12 +73,12 @@ function sx(props: any): SerializedStyles {
  *   }
  * }
  */
-interface VariantProps {
+export interface VariantProps {
   theme: Theme
   variant?: string
 }
 
-function variant({ variant, theme }: VariantProps) {
+export function variant({ variant, theme }: VariantProps) {
   const variantKey = variant && variant.split('.')[1]
   return css(
     get(

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@emotion/styled": "^10.0.27",
+    "@kodiak/box": "^0.1.0",
     "@styled-system/should-forward-prop": "^5.1.4",
     "@styled-system/space": "^5.1.2",
     "@theme-ui/css": "^0.3.1",

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@kodiak/flex",
+  "version": "0.0.1",
+  "description": "Kodiak's Flex component which is the base primitive component that all components are built from",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
+  "source": "src/index.ts",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "author": "Wesley Cole <wes@skyverge.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "prepare": "microbundle",
+    "watch": "microbundle watch"
+  },
+  "peerDependencies": {
+    "@emotion/core": "^10.0.27",
+    "react": "^16.12.0"
+  },
+  "dependencies": {
+    "@emotion/styled": "^10.0.27",
+    "@styled-system/should-forward-prop": "^5.1.4",
+    "@styled-system/space": "^5.1.2",
+    "@theme-ui/css": "^0.3.1",
+    "styled-system": "^5.1.4"
+  },
+  "devDependencies": {
+    "@types/styled-system": "^5.1.5",
+    "@types/styled-system__should-forward-prop": "^5.1.0",
+    "@types/theme-ui": "^0.2.7"
+  }
+}

--- a/packages/flex/src/Flex.tsx
+++ b/packages/flex/src/Flex.tsx
@@ -1,0 +1,6 @@
+import styled from '@emotion/styled'
+import { Box } from '@kodiak/box'
+
+export const Flex = styled(Box)({
+  display: 'flex',
+})

--- a/packages/flex/src/__tests__/Flex.spec.tsx
+++ b/packages/flex/src/__tests__/Flex.spec.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react'
+import serializer from 'jest-emotion'
+import renderer from 'react-test-renderer'
+import { Flex } from '../Flex'
+
+expect.addSnapshotSerializer(serializer)
+
+describe('Box', () => {
+  it('should render the Flex as a div element', () => {
+    expect(renderer.create(<Flex>Rendering Flex element</Flex>).toJSON())
+      .toMatchInlineSnapshot(`
+      .emotion-0 {
+        box-sizing: border-box;
+        margin: 0;
+        min-width: 0;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+      }
+
+      <div
+        className="emotion-0"
+      >
+        Rendering Flex element
+      </div>
+    `)
+  })
+
+  it('should style the element with the `sx` prop', () => {
+    expect(
+      renderer
+        .create(<Flex sx={{ color: 'white' }}>Rendering div element</Flex>)
+        .toJSON(),
+    ).toMatchInlineSnapshot(`
+      .emotion-0 {
+        box-sizing: border-box;
+        margin: 0;
+        min-width: 0;
+        color: white;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+      }
+
+      <div
+        className="emotion-0"
+      >
+        Rendering div element
+      </div>
+    `)
+  })
+
+  it('should style the element with styled-system props', () => {
+    expect(
+      renderer
+        .create(<Flex alignItems="center">Rendering div element</Flex>)
+        .toJSON(),
+    ).toMatchInlineSnapshot(`
+      .emotion-0 {
+        box-sizing: border-box;
+        margin: 0;
+        min-width: 0;
+        -webkit-align-items: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+      }
+
+      <div
+        className="emotion-0"
+      >
+        Rendering div element
+      </div>
+    `)
+  })
+})

--- a/packages/flex/src/index.ts
+++ b/packages/flex/src/index.ts
@@ -1,0 +1,1 @@
+export { Flex } from './Flex'

--- a/packages/flex/tsconfig.json
+++ b/packages/flex/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2017",
+    "noImplicitAny": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.test.*"]
+}

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -8,6 +8,8 @@
   },
   "dependencies": {
     "@babel/core": "^7.2.2",
+    "@kodiak/box": "^0.1.0",
+    "@kodiak/flex": "^0.0.1",
     "@storybook/addon-docs": "^5.3.9",
     "@storybook/addons": "^5.3.9",
     "@storybook/preset-typescript": "^1.2.0",

--- a/packages/storybook/src/Flex/Flex.stories.tsx
+++ b/packages/storybook/src/Flex/Flex.stories.tsx
@@ -1,8 +1,22 @@
 import * as React from 'react'
+import { Box } from '@kodiak/box'
 import { Flex } from '@kodiak/flex'
 
 export default { title: 'Flex' }
 
 export function initial() {
-  return <Flex>Basic Box that renders a Div</Flex>
+  return <Flex>Basic Box that renders a Div with `display: flex`</Flex>
+}
+
+export function alignItems() {
+  return (
+    <Flex alignItems="center" m={3} border="1px solid" borderColor="black">
+      <Box flex="1 1 auto" bg="primary" height={100} width={100}>
+        Item
+      </Box>
+      <Box bg="secondary" height={50} width={100}>
+        Item 2
+      </Box>
+    </Flex>
+  )
 }

--- a/packages/storybook/src/Flex/Flex.stories.tsx
+++ b/packages/storybook/src/Flex/Flex.stories.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import { Flex } from '@kodiak/flex'
+
+export default { title: 'Flex' }
+
+export function initial() {
+  return <Flex>Basic Box that renders a Div</Flex>
+}

--- a/packages/storybook/src/recipes/FlexRecipes.stories.tsx
+++ b/packages/storybook/src/recipes/FlexRecipes.stories.tsx
@@ -2,9 +2,9 @@ import * as React from 'react'
 import { Flex } from '@kodiak/flex'
 import { Box } from '@kodiak/box'
 
-export default { title: 'Recipes/FlexLayout' }
+export default { title: 'Recipes/Flexbox' }
 
-export function contentSidebar() {
+export function mainAside() {
   return (
     <Flex variant="layout.container">
       <Box as="header" variant="layout.header">
@@ -30,7 +30,7 @@ export function contentSidebar() {
   )
 }
 
-export function sidebarContentSidebar() {
+export function asideMainAside() {
   return (
     <Flex variant="layout.container">
       <Box as="header" variant="layout.header">
@@ -55,6 +55,16 @@ export function sidebarContentSidebar() {
       <Box as="footer" variant="layout.footer">
         Footer
       </Box>
+    </Flex>
+  )
+}
+
+export function grid() {
+  return (
+    <Flex flexWrap="wrap" p={4} m={4}>
+      {Array.from(Array(12).keys()).map(item => (
+        <Box key={item} bg="primary" height={100} width={100} m={3} />
+      ))}
     </Flex>
   )
 }

--- a/packages/storybook/src/recipes/FlexRecipes.stories.tsx
+++ b/packages/storybook/src/recipes/FlexRecipes.stories.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react'
+import { Flex } from '@kodiak/flex'
+import { Box } from '@kodiak/box'
+
+export default { title: 'Recipes/FlexLayout' }
+
+export function contentSidebar() {
+  return (
+    <Flex variant="layout.container">
+      <Box as="header" variant="layout.header">
+        Header
+      </Box>
+      <Flex variant="layout.root">
+        <Box
+          as="main"
+          variant="layout.main"
+          border="1px solid"
+          borderColor="black"
+        >
+          Main
+        </Box>
+        <Box as="aside" variant="layout.aside">
+          Aside
+        </Box>
+      </Flex>
+      <Box as="footer" variant="layout.footer">
+        Footer
+      </Box>
+    </Flex>
+  )
+}
+
+export function sidebarContentSidebar() {
+  return (
+    <Flex variant="layout.container">
+      <Box as="header" variant="layout.header">
+        Header
+      </Box>
+      <Flex variant="layout.root">
+        <Box as="aside" variant="layout.aside">
+          Aside
+        </Box>
+        <Box
+          as="main"
+          variant="layout.main"
+          border="1px solid"
+          borderColor="black"
+        >
+          Main
+        </Box>
+        <Box as="aside" variant="layout.aside">
+          Aside
+        </Box>
+      </Flex>
+      <Box as="footer" variant="layout.footer">
+        Footer
+      </Box>
+    </Flex>
+  )
+}

--- a/packages/storybook/src/theme.ts
+++ b/packages/storybook/src/theme.ts
@@ -40,7 +40,6 @@ export const theme = {
       flexDirection: 'column',
     },
     root: {
-      margin: 4,
       minHeight: '800px',
       justifyContent: 'space-between',
     },
@@ -51,11 +50,13 @@ export const theme = {
     },
     main: {
       maxWidth: 'main',
+      m: 4,
       width: '100%',
       p: 4,
     },
     aside: {
       maxWidth: 'aside',
+      m: 4,
       width: '100%',
       bg: 'muted',
       p: 2,

--- a/packages/storybook/src/theme.ts
+++ b/packages/storybook/src/theme.ts
@@ -24,11 +24,46 @@ export const theme = {
     secondary: '#30c',
     muted: '#f6f6f6',
   },
+  sizes: {
+    main: '60%',
+    aside: '25%',
+  },
   text: {
     heading: {
       fontFamily: 'heading',
       lineHeight: 'heading',
       fontWeight: 'heading',
+    },
+  },
+  layout: {
+    container: {
+      flexDirection: 'column',
+    },
+    root: {
+      margin: 4,
+      minHeight: '800px',
+      justifyContent: 'space-between',
+    },
+    header: {
+      color: 'white',
+      bg: 'primary',
+      p: 4,
+    },
+    main: {
+      maxWidth: 'main',
+      width: '100%',
+      p: 4,
+    },
+    aside: {
+      maxWidth: 'aside',
+      width: '100%',
+      bg: 'muted',
+      p: 2,
+    },
+    footer: {
+      color: 'white',
+      bg: 'secondary',
+      p: 4,
     },
   },
   styles: {


### PR DESCRIPTION
Creates the `Flex` primitive component which is a wrapper for the `Box` component and adds variant support to `Box`.

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch28154](https://app.clubhouse.io/jilt/story/28154/create-flexbox-examples-in-storybook-using-the-flex-component)

<a name="details"></a>

## Details

This creates a wrapping component on Box that adds the `display: flex` property. 

The majority of this work is adding the `variant` prop to the Box component. This will allow all components that wrap `Box` and for `Box` itself to be styled by variants. This will allow developers to create variants in the theme like:

```
// theme.js
{
  ...baseTheme,
  buttons: {
    primary: {
      bg: 'primary',
      color: 'white',
    },
    secondary: {
      bg: 'secondary',
      color: 'black',
    }
  }
}
```

A variant can then be applied to a component in the following way:

```
<Box variant="buttons.primary">Box content</Box>
```

This PR will address changes to the following:

- [x] Components
- [ ] Hooks

<a name="qa"></a>

## Acceptance Crtieria

- [x] Flex should render a `div` element with the `display: flex` property on it
- [x] Flex should have all of the flexbox styled-system props available
- [x] Box and Flex should accept the `variant` prop
- [x] Box and Flex should be styled according to the variant defined in the theme

<a name="API Changes"></a>

## API Changes

- [ ] **[Breaking]** This PR introduces breaking changes
- [ ] **[Documentation]** Documentation has been written about the API change

<!-- Details about any API changes that have occurred to a component or hook -->

<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [x] **[QA]** User-testing/quality assurance done
- [x] **[Test]** All components and hooks should have a corresponding unit test
- [x] **[Storybook]** All components and hooks should have a corresponding Storybook story
- [ ] **[Documentation]** Documentation has been written or updated
- [ ] **[Version]** Version number has been updated
