### PR TITLE
Create the Text component

### DIFF
--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -33,5 +33,6 @@
     "@types/styled-system": "^5.1.5",
     "@types/styled-system__should-forward-prop": "^5.1.0",
     "@types/theme-ui": "^0.2.7"
-  }
+  },
+  "gitHead": "b841ac00c2973b57c3539c600bcdd4c4d37c0a8a"
 }

--- a/packages/primitives/src/Box/Box.tsx
+++ b/packages/primitives/src/Box/Box.tsx
@@ -50,7 +50,7 @@ const shouldForwardProp = createShouldForwardProp([
  *
  * @param props any
  */
-function sx(props: any): SerializedStyles {
+export function sx(props: any): SerializedStyles {
   return css(props.sx)(props.theme)
 }
 

--- a/packages/primitives/src/Box/index.ts
+++ b/packages/primitives/src/Box/index.ts
@@ -1,1 +1,1 @@
-export { Box } from './Box'
+export { Box, variant, sx } from './Box'

--- a/packages/primitives/src/Text/Text.tsx
+++ b/packages/primitives/src/Text/Text.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled'
+import {
+  space,
+  color,
+  typography,
+  SpaceProps,
+  ColorProps,
+  TypographyProps,
+} from 'styled-system'
+import { createShouldForwardProp } from '@styled-system/should-forward-prop'
+import { variant, sx } from '../Box'
+
+const shouldForwardProp = createShouldForwardProp([
+  ...(space.propNames as string[]),
+  ...(color.propNames as string[]),
+  ...(typography.propNames as string[]),
+])
+
+type TextProps = {
+  as?: React.ElementType
+  variant?: string
+} & SpaceProps &
+  ColorProps &
+  TypographyProps
+
+export const Text = styled<'p', TextProps>('p', {
+  shouldForwardProp,
+})(
+  {
+    boxSizing: 'border-box',
+    margin: 0,
+    minWidth: 0,
+  },
+  variant,
+  space,
+  color,
+  typography,
+  sx,
+)

--- a/packages/primitives/src/Text/__tests__/Text.spec.tsx
+++ b/packages/primitives/src/Text/__tests__/Text.spec.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react'
+import serializer from 'jest-emotion'
+import renderer from 'react-test-renderer'
+import { Text } from '../Text'
+
+expect.addSnapshotSerializer(serializer)
+
+describe('Text', () => {
+  it('should render the Text as a p element', () => {
+    expect(renderer.create(<Text>Rendering p element</Text>).toJSON())
+      .toMatchInlineSnapshot(`
+      .emotion-0 {
+        box-sizing: border-box;
+        margin: 0;
+        min-width: 0;
+      }
+
+      <p
+        className="emotion-0"
+      >
+        Rendering p element
+      </p>
+    `)
+  })
+
+  it('should render the Text component as a span element', () => {
+    expect(
+      renderer.create(<Text as="span">Rendering span element</Text>).toJSON(),
+    ).toMatchInlineSnapshot(`
+      .emotion-0 {
+        box-sizing: border-box;
+        margin: 0;
+        min-width: 0;
+      }
+
+      <span
+        className="emotion-0"
+      >
+        Rendering span element
+      </span>
+    `)
+  })
+
+  it('should style the element with the `sx` prop', () => {
+    expect(
+      renderer
+        .create(<Text sx={{ color: 'white' }}>Rendering p with sx prop</Text>)
+        .toJSON(),
+    ).toMatchInlineSnapshot(`
+      .emotion-0 {
+        box-sizing: border-box;
+        margin: 0;
+        min-width: 0;
+        color: white;
+      }
+
+      <p
+        className="emotion-0"
+      >
+        Rendering p with sx prop
+      </p>
+    `)
+  })
+
+  it('should style the element with styled-system props', () => {
+    expect(
+      renderer
+        .create(<Text fontWeight="bold">Rendering bold p tag</Text>)
+        .toJSON(),
+    ).toMatchInlineSnapshot(`
+      .emotion-0 {
+        box-sizing: border-box;
+        margin: 0;
+        min-width: 0;
+        font-weight: bold;
+      }
+
+      <p
+        className="emotion-0"
+      >
+        Rendering bold p tag
+      </p>
+    `)
+  })
+})

--- a/packages/primitives/src/Text/index.ts
+++ b/packages/primitives/src/Text/index.ts
@@ -1,0 +1,1 @@
+export { Text } from './Text'

--- a/packages/primitives/src/index.ts
+++ b/packages/primitives/src/index.ts
@@ -1,2 +1,3 @@
 export { Box } from './Box'
 export { Flex } from './Flex'
+export { Text } from './Text'

--- a/packages/storybook/src/primitives/Box/Box.stories.tsx
+++ b/packages/storybook/src/primitives/Box/Box.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Box } from '@kodiak/primitives'
 
-export default { title: 'Box' }
+export default { title: 'Primitives/Box' }
 
 export function initial() {
   return (

--- a/packages/storybook/src/primitives/Flex/Flex.stories.tsx
+++ b/packages/storybook/src/primitives/Flex/Flex.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Box, Flex } from '@kodiak/primitives'
 
-export default { title: 'Flex' }
+export default { title: 'Primitives/Flex' }
 
 export function initial() {
   return <Flex>Basic Box that renders a Div with `display: flex`</Flex>

--- a/packages/storybook/src/primitives/Text/Text.stories.tsx
+++ b/packages/storybook/src/primitives/Text/Text.stories.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react'
+import { Box, Text } from '@kodiak/primitives'
+
+export default { title: 'Primitives/Text' }
+
+export function initial() {
+  return (
+    <Box>
+      <Text>Renders a `p` tag by default</Text>
+    </Box>
+  )
+}
+
+export function asProp() {
+  return (
+    <Box as="span">
+      <Text as="span">Renders the Text component as a `span` HTML element</Text>
+    </Box>
+  )
+}
+
+export function styledSystemProps() {
+  return (
+    <Box>
+      <Text color="primary" fontWeight="bold" fontSize={24} m={4}>
+        Renders the Text and styles it with styled-system props
+      </Text>
+    </Box>
+  )
+}
+
+export function variant() {
+  return (
+    <Box>
+      <Text as="h1" variant="text.heading">
+        Renders text in `h1` with the heading variant
+      </Text>
+    </Box>
+  )
+}

--- a/packages/storybook/src/theme.ts
+++ b/packages/storybook/src/theme.ts
@@ -33,7 +33,7 @@ export const theme = {
       fontFamily: 'heading',
       lineHeight: 'heading',
       fontWeight: 'heading',
-      fontSize: 32,
+      fontSize: 5,
     },
   },
   layout: {

--- a/packages/storybook/src/theme.ts
+++ b/packages/storybook/src/theme.ts
@@ -33,6 +33,7 @@ export const theme = {
       fontFamily: 'heading',
       lineHeight: 'heading',
       fontWeight: 'heading',
+      fontSize: 32,
     },
   },
   layout: {


### PR DESCRIPTION
Creates the Text component which renders a `p` tag by default. 

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch28141](https://app.clubhouse.io/jilt/story/28141/create-the-text-component)

<a name="details"></a>

## Details

Follows the same structure as the `Box` component. Will render a styled `p` tag by default but accepts the `as` prop for changing the rendered element. 

`Text` only supports the following styled-system props:

- space
- color
- typography

Text also supports variants out of the box.

This PR will address changes to the following:

- [x] Components
- [ ] Hooks

<a name="qa"></a>

## Acceptance Crtieria

- [x] Component should accept theme properties and scales
- [x] Component should forward ref
- [x] Should have an associated Storybook story
- [x] Should be fully typed
- [x] Content should be readable and navigable by the screen reader and keyboard

<a name="API Changes"></a>

## API Changes

- [ ] **[Breaking]** This PR introduces breaking changes
- [ ] **[Documentation]** Documentation has been written about the API change

<!-- Details about any API changes that have occurred to a component or hook -->

<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [x] **[QA]** User-testing/quality assurance done
- [x] **[Test]** All components and hooks should have a corresponding unit test
- [x] **[Storybook]** All components and hooks should have a corresponding Storybook story
- [ ] **[Documentation]** Documentation has been written or updated
- [ ] **[Version]** Version number has been updated
